### PR TITLE
Replacing `SenderType` with `Class<?>`

### DIFF
--- a/api/src/main/java/io/github/jwdeveloper/commands/api/Commands.java
+++ b/api/src/main/java/io/github/jwdeveloper/commands/api/Commands.java
@@ -3,8 +3,10 @@ package io.github.jwdeveloper.commands.api;
 import io.github.jwdeveloper.commands.api.argumetns.ArgumentsTypesRegistry;
 import io.github.jwdeveloper.commands.api.builders.CommandBuilder;
 import io.github.jwdeveloper.commands.api.builders.DefaultCommandBuilder;
+import io.github.jwdeveloper.commands.api.data.CommandProperties;
 import io.github.jwdeveloper.commands.api.patterns.PatternsRegistry;
 import io.github.jwdeveloper.commands.api.services.ActionsRegistry;
+import io.github.jwdeveloper.commands.api.services.CommandSenderRegistry;
 import io.github.jwdeveloper.dependance.api.DependanceContainer;
 
 import java.util.List;
@@ -29,6 +31,12 @@ public interface Commands {
      * @return a new instance of {@link ArgumentsTypesRegistry}.
      */
     ArgumentsTypesRegistry argumentTypes();
+
+    /**
+     * Command sender registry object, modify to add new valid command senders
+     * @return an instance of {@link CommandSenderRegistry}.
+     */
+    CommandSenderRegistry commandSenders();
 
     /**
      * Creates a new command builder for a command with the specified pattern.

--- a/api/src/main/java/io/github/jwdeveloper/commands/api/builders/CommandPropsBuilder.java
+++ b/api/src/main/java/io/github/jwdeveloper/commands/api/builders/CommandPropsBuilder.java
@@ -1,7 +1,6 @@
 package io.github.jwdeveloper.commands.api.builders;
 
 import io.github.jwdeveloper.commands.api.data.CommandProperties;
-import io.github.jwdeveloper.commands.api.data.SenderType;
 
 import java.util.Arrays;
 import java.util.function.Consumer;
@@ -138,7 +137,7 @@ public interface CommandPropsBuilder<BUILDER> {
      * @param senderTypes one or more sender type
      * @return builder
      */
-    default BUILDER withExcludedSenders(SenderType... senderTypes) {
+    default BUILDER withExcludedSenders(Class<?>... senderTypes) {
         return withProperties(commandProperties ->
         {
             properties().excludedSenders().addAll(Arrays.stream(senderTypes).toList());

--- a/api/src/main/java/io/github/jwdeveloper/commands/api/data/CommandProperties.java
+++ b/api/src/main/java/io/github/jwdeveloper/commands/api/data/CommandProperties.java
@@ -24,7 +24,7 @@ public class CommandProperties {
      * Contains list of Sender types can
      * CAN NOT use this command
      */
-    private List<SenderType> excludedSenders = new ArrayList<>();
+    private List<Class<?>> excludedSenders = new ArrayList<>();
 
     /**
      * Command short description

--- a/api/src/main/java/io/github/jwdeveloper/commands/api/services/CommandSenderRegistry.java
+++ b/api/src/main/java/io/github/jwdeveloper/commands/api/services/CommandSenderRegistry.java
@@ -1,0 +1,46 @@
+package io.github.jwdeveloper.commands.api.services;
+
+import io.github.jwdeveloper.commands.api.data.CommandProperties;
+
+import java.util.Set;
+
+/* Created by Conor on 10.09.2024 */
+public interface CommandSenderRegistry {
+
+    /**
+     * Registers the given class for future use as a command sender
+     * @param commandSenderClazz Class of the command sender
+     * @apiNote See {@link CommandProperties#excludedSenders()} for usage of these registered classes
+     */
+    void register(Class<?> commandSenderClazz);
+
+    /**
+     * Unregisters the given class from the possible list of command senders
+     * @param commandSenderClazz Class of the command sender
+     */
+    void unregister(Class<?> commandSenderClazz);
+
+    /**
+     * @param commandSenderClazz Class of the sende to check
+     * @return True if registered, false otherwise
+     */
+    default boolean isRegistered(Class<?> commandSenderClazz) {
+        return getCommandSenders().stream()
+                .anyMatch(commandSenderClazz::isAssignableFrom);
+    }
+
+    /**
+     * @param commandSenderClassName Name of the class, eg. "Player"
+     * @return True if registered, false otherwise
+     */
+    default boolean isRegistered(String commandSenderClassName) {
+        return getCommandSenders().stream()
+                .anyMatch((cs) -> commandSenderClassName.equalsIgnoreCase(cs.getSimpleName()));
+    }
+
+    /**
+     * @return Registered command sender classes
+     */
+    Set<Class<?>> getCommandSenders();
+
+}

--- a/core/src/main/java/io/github/jwdeveloper/commands/core/CommandFrameworkBuilder.java
+++ b/core/src/main/java/io/github/jwdeveloper/commands/core/CommandFrameworkBuilder.java
@@ -1,6 +1,8 @@
 package io.github.jwdeveloper.commands.core;
 
+import io.github.jwdeveloper.commands.api.services.CommandSenderRegistry;
 import io.github.jwdeveloper.commands.api.services.ValidationService;
+import io.github.jwdeveloper.commands.core.impl.DefaultCommandSenderRegistry;
 import io.github.jwdeveloper.commands.core.impl.parsers.BoolParser;
 import io.github.jwdeveloper.commands.core.impl.parsers.NumberParser;
 import io.github.jwdeveloper.commands.core.impl.parsers.TextParser;
@@ -43,6 +45,7 @@ public class CommandFrameworkBuilder {
         containerBuilder.registerSingleton(ArgumentsTypesRegistry.class, DefaultArgumentTypesRegistry.class);
         containerBuilder.registerSingleton(MessagesService.class, DefaultMessagesService.class);
         containerBuilder.registerSingleton(ValidationService.class, DefaultValidationService.class);
+        containerBuilder.registerSingleton(CommandSenderRegistry.class, DefaultCommandSenderRegistry.class);
 
         containerBuilder.registerTransient(ArgumentTypeBuilder.class, ArgumentTypeBuilderImpl.class);
         containerBuilder.registerTransient(CommandBuilder.class, CommandBuilderImpl.class);

--- a/core/src/main/java/io/github/jwdeveloper/commands/core/impl/DefaultCommandSenderRegistry.java
+++ b/core/src/main/java/io/github/jwdeveloper/commands/core/impl/DefaultCommandSenderRegistry.java
@@ -1,0 +1,28 @@
+package io.github.jwdeveloper.commands.core.impl;
+
+import io.github.jwdeveloper.commands.api.services.CommandSenderRegistry;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+/* Created by Conor on 10.09.2024 */
+public class DefaultCommandSenderRegistry implements CommandSenderRegistry {
+
+    private final Set<Class<?>> commandSenders = new HashSet<>();
+
+    @Override
+    public void register(Class<?> commandSenderClazz) {
+       commandSenders.add(commandSenderClazz);
+    }
+
+    @Override
+    public void unregister(Class<?> commandSenderClazz) {
+        commandSenders.remove(commandSenderClazz);
+    }
+
+    @Override
+    public Set<Class<?>> getCommandSenders() {
+        return Collections.unmodifiableSet(commandSenders);
+    }
+}

--- a/core/src/main/java/io/github/jwdeveloper/commands/core/impl/DefaultCommands.java
+++ b/core/src/main/java/io/github/jwdeveloper/commands/core/impl/DefaultCommands.java
@@ -1,5 +1,6 @@
 package io.github.jwdeveloper.commands.core.impl;
 
+import io.github.jwdeveloper.commands.api.services.CommandSenderRegistry;
 import io.github.jwdeveloper.dependance.api.DependanceContainer;
 import io.github.jwdeveloper.commands.api.Command;
 import io.github.jwdeveloper.commands.api.Commands;
@@ -27,6 +28,7 @@ public class DefaultCommands implements Commands {
     private final PatternsRegistry patterns;
     private final DependanceContainer container;
     private final ArgumentsTypesRegistry argumentTypes;
+    private final CommandSenderRegistry commandSenders;
 
     public DefaultCommands(CommandsRegistry commandsRegistry,
                            DependanceContainer container,
@@ -34,7 +36,8 @@ public class DefaultCommands implements Commands {
                            TemplateParser commandsTemplate,
                            PatternBuilderVisitor patternService,
                            ActionsRegistry actionsRegistry,
-                           PatternsRegistry patterns) {
+                           PatternsRegistry patterns,
+                           CommandSenderRegistry commandSenders) {
         this.patterns = patterns;
         this.commandsRegistry = commandsRegistry;
         this.container = container;
@@ -42,6 +45,7 @@ public class DefaultCommands implements Commands {
         this.patternService = patternService;
         this.argumentTypes = argumentTypesRegistry;
         this.actions = actionsRegistry;
+        this.commandSenders = commandSenders;
     }
 
     @Override

--- a/spigot/src/main/java/io/github/jwdeveloper/commands/spigot/CommandsFramework.java
+++ b/spigot/src/main/java/io/github/jwdeveloper/commands/spigot/CommandsFramework.java
@@ -15,7 +15,9 @@ import io.github.jwdeveloper.commands.spigot.impl.parsers.LocationParser;
 import io.github.jwdeveloper.commands.core.impl.parsers.NumberParser;
 import io.github.jwdeveloper.commands.spigot.impl.parsers.PlayerParser;
 import org.bukkit.*;
+import org.bukkit.command.*;
 import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Player;
 import org.bukkit.event.server.PluginDisableEvent;
 import org.bukkit.plugin.Plugin;
 
@@ -45,6 +47,13 @@ public class CommandsFramework {
 
             action.accept(container);
         });
+        var senders = commands.commandSenders();
+        senders.register(Player.class);
+        senders.register(ConsoleCommandSender.class);
+        senders.register(ProxiedCommandSender.class);
+        senders.register(BlockCommandSender.class);
+        senders.register(RemoteConsoleCommandSender.class);
+
         var argumentTypes = commands.argumentTypes();
 
         argumentTypes.register(new PlayerParser());

--- a/spigot/src/main/java/io/github/jwdeveloper/commands/spigot/api/SpigotCommandBuilder.java
+++ b/spigot/src/main/java/io/github/jwdeveloper/commands/spigot/api/SpigotCommandBuilder.java
@@ -1,12 +1,21 @@
 package io.github.jwdeveloper.commands.spigot.api;
 
 import io.github.jwdeveloper.commands.api.builders.CommandBuilder;
+import io.github.jwdeveloper.commands.api.data.CommandProperties;
 import io.github.jwdeveloper.commands.api.functions.CommandEventInvoker;
 import org.bukkit.command.*;
 import org.bukkit.entity.Player;
 
+import java.util.function.Consumer;
+
 public interface SpigotCommandBuilder extends CommandBuilder<SpigotCommandBuilder, CommandSender> {
 
+    // Conor-10.09.2024: Is this correct?! Otherwise, I get a NPE when trying to use #withExcludedSenders,
+    // because CommandBuilder#withProperties returns null
+    @Override
+    default SpigotCommandBuilder withProperties(Consumer<CommandProperties> properties) {
+        return this;
+    }
 
     /**
      * Registers an event action to be executed when a command is run by a ProxiedCommandSender.

--- a/spigot/src/main/java/io/github/jwdeveloper/commands/spigot/impl/services/SpigotValidationService.java
+++ b/spigot/src/main/java/io/github/jwdeveloper/commands/spigot/impl/services/SpigotValidationService.java
@@ -2,24 +2,22 @@ package io.github.jwdeveloper.commands.spigot.impl.services;
 
 import io.github.jwdeveloper.commands.api.Command;
 import io.github.jwdeveloper.commands.api.data.ActionResult;
-import io.github.jwdeveloper.commands.api.data.SenderType;
 import io.github.jwdeveloper.commands.api.data.events.CommandValidationEvent;
+import io.github.jwdeveloper.commands.api.services.CommandSenderRegistry;
 import io.github.jwdeveloper.commands.api.services.MessagesService;
 import io.github.jwdeveloper.commands.api.services.ValidationService;
 import io.github.jwdeveloper.commands.core.impl.services.CommandEventsImpl;
-import org.bukkit.command.BlockCommandSender;
-import org.bukkit.command.ConsoleCommandSender;
-import org.bukkit.command.ProxiedCommandSender;
-import org.bukkit.command.RemoteConsoleCommandSender;
 import org.bukkit.entity.Player;
 
 import java.util.List;
 
 public class SpigotValidationService implements ValidationService {
     private final MessagesService messages;
+    private final CommandSenderRegistry senders;
 
-    public SpigotValidationService(MessagesService messagesService) {
-        this.messages = messagesService;
+    public SpigotValidationService(MessagesService messages, CommandSenderRegistry senders) {
+        this.messages = messages;
+        this.senders = senders;
     }
 
     public ActionResult<Command> validateCommand(Command command, Object sender, String[] args) {
@@ -65,17 +63,12 @@ public class SpigotValidationService implements ValidationService {
         return ActionResult.success(sender);
     }
 
-    public ActionResult<Object> isSenderEnabled(Object sender, List<SenderType> senderTypes) {
-        for (var accessType : senderTypes) {
-            var isDisabled = switch (accessType) {
-                case PLAYER -> sender instanceof Player;
-                case CONSOLE -> sender instanceof ConsoleCommandSender;
-                case PROXY -> sender instanceof ProxiedCommandSender;
-                case BLOCK -> sender instanceof BlockCommandSender;
-                case REMOTE_CONSOLE -> sender instanceof RemoteConsoleCommandSender;
-            };
-            if (isDisabled) {
-                return ActionResult.failed(accessType.name());
+    public ActionResult<Object> isSenderEnabled(Object sender, List<Class<?>> excludedSenders) {
+        if (!senders.isRegistered(sender.getClass())) return ActionResult.failed(String.format("Unregistered sender %s", sender.getClass().getSimpleName()));
+
+        for (var accessType : excludedSenders) {
+            if (sender.getClass().isAssignableFrom(accessType)) {
+                return ActionResult.failed(accessType.getSimpleName());
             }
         }
         return ActionResult.success(sender);

--- a/spigot/src/test/java/io/github/jwdeveloper/commands/spigot/tests/SenderTest.java
+++ b/spigot/src/test/java/io/github/jwdeveloper/commands/spigot/tests/SenderTest.java
@@ -1,0 +1,34 @@
+package io.github.jwdeveloper.commands.spigot.tests;
+
+import io.github.jwdeveloper.commands.spigot.tests.common.SpigotTestBase;
+import org.bukkit.command.BlockCommandSender;
+import org.junit.jupiter.api.Test;
+
+/* Created by Conor on 10.09.2024 */
+public class SenderTest extends SpigotTestBase {
+
+    @Test
+    public void testValidSenders() {
+        var cmd = api.create("/t <name:Text> <age:Number>")
+                .withExcludedSenders(BlockCommandSender.class)
+                .onPlayerExecute((p) -> System.out.println("Player invoked") )
+                .build();
+
+        final var result = cmd.executeCommand(playerSender, "", "c", "1");
+        assertTrue(result);
+    }
+
+    @Test
+    public void testInvalidSenders() {
+        api.commandSenders().unregister(BlockCommandSender.class);
+
+        var cmd = api.create("/t <name:Text> <age:Number>")
+                .withExcludedSenders(BlockCommandSender.class)
+                .onPlayerExecute((p) -> System.out.println("Player invoked") )
+                .onBlockExecute((b) -> System.out.println("Block invoked") )    // Shouldn't happen
+                .build();
+
+        final var result = cmd.executeCommand(blockSender, "", "c", "1");
+        assertFalse(result);
+    }
+}

--- a/spigot/src/test/java/io/github/jwdeveloper/commands/spigot/tests/common/SpigotTestBase.java
+++ b/spigot/src/test/java/io/github/jwdeveloper/commands/spigot/tests/common/SpigotTestBase.java
@@ -6,11 +6,20 @@ import io.github.jwdeveloper.commands.api.CommandsRegistry;
 import io.github.jwdeveloper.commands.api.builders.CommandBuilder;
 import io.github.jwdeveloper.commands.api.data.ActionResult;
 import io.github.jwdeveloper.commands.api.data.events.CommandEvent;
+import io.github.jwdeveloper.commands.api.services.ValidationService;
 import io.github.jwdeveloper.commands.core.impl.DefaultCommandsRegistry;
 import io.github.jwdeveloper.commands.spigot.CommandsFramework;
+import io.github.jwdeveloper.commands.spigot.api.SpigotCommandBuilder;
 import io.github.jwdeveloper.commands.spigot.api.SpigotCommands;
+import io.github.jwdeveloper.commands.spigot.impl.PluginDisableListener;
+import io.github.jwdeveloper.commands.spigot.impl.SpigotCommandsRegistry;
+import io.github.jwdeveloper.commands.spigot.impl.services.SpigotValidationService;
 import org.bukkit.Bukkit;
 import org.bukkit.Server;
+import org.bukkit.command.BlockCommandSender;
+import org.bukkit.command.ConsoleCommandSender;
+import org.bukkit.command.ProxiedCommandSender;
+import org.bukkit.command.RemoteConsoleCommandSender;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.PluginManager;
@@ -31,6 +40,7 @@ public abstract class SpigotTestBase {
     protected MockedStatic<Bukkit> bukkitMock;
 
     protected Player playerSender;
+    protected BlockCommandSender blockSender;
 
     protected void onBefore(Commands commands) {
 
@@ -77,6 +87,7 @@ public abstract class SpigotTestBase {
     public void setUp() {
         var plugin = mock(Plugin.class);
         playerSender = mock(Player.class);
+        blockSender = mock(BlockCommandSender.class);
         bukkitMock = mockStatic(Bukkit.class);
 
         // Create mock Server and PluginManager instances
@@ -89,6 +100,7 @@ public abstract class SpigotTestBase {
         api = CommandsFramework.enable(plugin, builder ->
         {
             builder.registerSingleton(CommandsRegistry.class, DefaultCommandsRegistry.class);
+            builder.registerSingleton(ValidationService.class, SpigotValidationService.class);
         });
         onBefore(api);
     }


### PR DESCRIPTION
This code could, as of yet, not be tested; Or rather, the test doesn't work correctly. Using the debugger it was obvious that the `SpigotValidationService#validateCommand` method was never called. Instead `DefaultValidationService#validateCommand` is called instead, which always returns a success.